### PR TITLE
Update this plugin to the new event api 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
+jdk:
+ - oraclejdk8
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.23
-script: 
-  - bundle exec rspec spec
+ - jruby-1.7.25
+script:
+ - bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
-# 2.0.4
+## 3.0.0
+  - Uses the new plugin api
+  - relax contraints on the logstash-core-plugin-api
+  - update the travis file for jruby 1.7.25
+
+## 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.3
+
+## 2.0.3
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/outputs/boundary.rb
+++ b/lib/logstash/outputs/boundary.rb
@@ -79,7 +79,7 @@ class LogStash::Outputs::Boundary < LogStash::Outputs::Base
     boundary_event['tags'] = @btags.collect { |x| event.sprintf(x) } if @btags
 
     if @auto
-      boundary_fields = event['@fields'].select { |k| boundary_keys.member? k }
+      boundary_fields = event.get('@fields').select { |k| boundary_keys.member? k }
       boundary_event = boundary_fields.merge boundary_event
     end
 

--- a/logstash-output-boundary.gemspec
+++ b/logstash-output-boundary.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-output-boundary'
-  s.version         = '2.0.4'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you send annotations to Boundary based on Logstash events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
- update .travis.yml
- uses the new accessor
- relax constraints for the logstash-core