### PR TITLE
Change api_key config type to password to prevent from leaks in debug logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.6
+  - Change `api_key` config type to `password` to prevent from leaks in debug logs [#8](https://github.com/logstash-plugins/logstash-output-boundary/pull/8)
+
 ## 3.0.5
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -58,7 +58,7 @@ output plugins.
 ===== `api_key` 
 
   * This is a required setting.
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 Your Boundary API key

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -39,7 +39,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
-| <<plugins-{type}s-{plugin}-api_key>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-api_key>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-auto>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-bsubtype>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-btags>> |<<array,array>>|No

--- a/lib/logstash/outputs/boundary.rb
+++ b/lib/logstash/outputs/boundary.rb
@@ -16,7 +16,7 @@ class LogStash::Outputs::Boundary < LogStash::Outputs::Base
   config_name "boundary"
 
   # Your Boundary API key
-  config :api_key, :validate => :string, :required => true
+  config :api_key, :validate => :password, :required => true
 
   # Your Boundary Org ID
   config :org_id, :validate => :string, :required => true
@@ -93,7 +93,7 @@ class LogStash::Outputs::Boundary < LogStash::Outputs::Base
     }.merge boundary_event
 
     request = Net::HTTP::Post.new(@uri.path)
-    request.basic_auth(@api_key, '')
+    request.basic_auth(@api_key.value, '')
 
     @logger.debug("Boundary event", :boundary_event => boundary_event)
 

--- a/logstash-output-boundary.gemspec
+++ b/logstash-output-boundary.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-boundary'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends annotations to Boundary based on Logstash events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/boundary_spec.rb
+++ b/spec/outputs/boundary_spec.rb
@@ -3,4 +3,18 @@ require "logstash/devutils/rspec/spec_helper"
 require 'logstash/outputs/boundary'
 
 describe LogStash::Outputs::Boundary do
+
+  let(:plugin) { described_class.new(config) }
+
+  describe "debugging `api_key`" do
+    let(:config) {{ "org_id" => "my-org-id", "api_key" => "$ecre&-key" }}
+
+    it "should not show origin value" do
+      expect(plugin.logger).to receive(:debug).with('<password>')
+
+      plugin.register
+      plugin.logger.send(:debug, plugin.api_key.to_s)
+    end
+  end
+
 end


### PR DESCRIPTION
When running Logstash with `--config.debug`, `api_key` may be leaked in the debug logs. This PR changes `api_key` type to `password` to prevent from leaks. 

- Closes: #7 